### PR TITLE
Restricted file permissions on log file

### DIFF
--- a/logger/file_plugin.go
+++ b/logger/file_plugin.go
@@ -35,7 +35,7 @@ func NewFilePlugin(filePluginOptions FilePluginOptions) (Plugin, error) {
 	case "stderr":
 		plugin.file = os.Stderr
 	default:
-		plugin.file, err = os.OpenFile(filePluginOptions.Path, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0666)
+		plugin.file, err = os.OpenFile(filePluginOptions.Path, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0640)
 	}
 	return plugin, err
 }


### PR DESCRIPTION
Addressing the issue #36 

**Description**

Restricting the log file's permissions to 0640.

**Motivation**

We are currently using 0666 which gives complete unrestricted access to anyone using the same system. If maliciously used this lets an adversary create false logs.

Using 0640 will allow users in the same group (e.g. users that are consuming logs) to read from the file while ensuring that only the Darknode can write to it.

