### PR TITLE
Generator for the order matching engine

### DIFF
--- a/orderbook/sync.go
+++ b/orderbook/sync.go
@@ -17,14 +17,16 @@ type Change struct {
 	OrderParity   order.Parity
 	OrderStatus   order.Status
 	OrderPriority uint64
+	OrderTrader   string
 }
 
-func NewChange(id order.ID, parity order.Parity, status order.Status, priority uint64) Change {
+func NewChange(id order.ID, parity order.Parity, status order.Status, priority uint64, trader string) Change {
 	return Change{
 		OrderID:       id,
 		OrderParity:   parity,
 		OrderStatus:   status,
 		OrderPriority: priority,
+		OrderTrader:   trader,
 	}
 }
 


### PR DESCRIPTION
**Description**

Continue of PR  #47 . The ome needs to check the balance before generating computations to the computer.  

We introduce a new component called the generator which validates the trader balance against all his open orders.  The generator is also responsible for checking the existence of order fragment for each Order. It then outputs the validated orders to the ranker.

**Motivation**

We verify the balance in order to avoid trader spending more than what he has. 

**Design**

- Generator 
The generator will be responsible for generating valid computation and output it to the computer.

- RenLedger
We'll add function for retrieving order details in the orderbook in bulk which should include the order ID, order status, trader address. We also need to remove some unused fields store in the Leger, i.e. order parity and order type.

- Computer 
We introduce a new stage 0 for validating share of balance. The computation ID should be set by the generator including the last byte which indicates the stage. 

- Others 
The order tokens need to be public so we can know which token balance we need to check.
Move the token filter at the front. 
Check expiry date of the order ( done in computer and generator , checked in Orderbook ledger)

**Unresolved Issues**

- Priority back off factor.
The order priority should be affected by some factor relating to time or number of computations involved. It gives new orders a chance to get computed after the old orders been computation a lot of times. 


