### PR TITLE
Epoch

### DIFF
--- a/orderbook/orderbook_test.go
+++ b/orderbook/orderbook_test.go
@@ -69,7 +69,7 @@ func (syncer *mockSyncer) Sync() (ChangeSet, error) {
 			changes[i] = Change{
 				OrderID:       ord.ID,
 				OrderParity:   ord.Parity,
-				OrderPriority: uint64(i),
+				OrderPriority: Priority(i),
 				OrderStatus:   order.Open,
 			}
 			i++

--- a/orderbook/sync_test.go
+++ b/orderbook/sync_test.go
@@ -39,7 +39,7 @@ var _ = Describe("Syncer", func() {
 		})
 
 		It("should be able to sync new opened orders", func() {
-			priority := uint64(1)
+			priority := Priority(1)
 			for i := 0; i < NumberOfOrderPairs; i++ {
 				err := renLedger.OpenBuyOrder([65]byte{}, buys[i].ID)
 				Ω(err).ShouldNot(HaveOccurred())

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -190,3 +190,7 @@ func (darkpool *mockDarkpool) IsRegistered(addr identity.Address) (bool, error) 
 	_, ok := darkpool.darknodes[addr]
 	return ok, nil
 }
+
+func (darkpool *mockDarkpool) NextEpoch() (cal.Epoch, error) {
+	panic("unimplemented")
+}


### PR DESCRIPTION
**Description**

This PR will introduce epoch handling for the orderbook and the ome. 

**Motivation**

The darknode needs to handle orders from different epochs. For the ome, we want the ranker only create computations with orders from the same epoch. 

**Design**

- Ranker
We introduce a new struct epochRanker which is only responsible for orders from one specific epoch.  And the Ranker becomes a delegate ranker delegates orders to specific epochRanker.
Currently we will only have two epochRankers, one for previous epoch and one for current epoch. 
When new epoch happens, the previous epochRanker will be dropped and a new epochRanker will be created for the new epoch. 

- DarknodeRegistry
The DNR contract needs to store the block number in which epoch happens. So the bindings and interface needs to be updated.

- Ledger
The ledger needs to store the block number when the order status is been modfied. So the bindings and interface needs to be updated.

- Orderbook 
The change set will including the block number where the change happens. 

- cmd
The darknode cmd needs to updated to accecpt the new ranker and new orderbook. 


