### PR TITLE
Status contracts

### DIFF
--- a/cmd/darknode/darknode.go
+++ b/cmd/darknode/darknode.go
@@ -119,6 +119,8 @@ func main() {
 	statusProvider.WriteNetwork(string(config.Ethereum.Network))
 	statusProvider.WriteMultiAddress(multiAddr)
 	statusProvider.WriteEthereumAddress(auth.From.Hex())
+	statusProvider.WriteDarknodeRegistryAddress(config.Ethereum.DarknodeRegistryAddress)
+	statusProvider.WriteRewardVaultAddress(config.Ethereum.RewardVaultAddress)
 
 	pk, err := crypto.BytesFromRsaPublicKey(&config.Keystore.RsaKey.PublicKey)
 	if err != nil {

--- a/http/adapter/status.go
+++ b/http/adapter/status.go
@@ -8,11 +8,13 @@ import (
 
 // Status defines a structure for JSON marshalling
 type Status struct {
-	Network         string `json:"network"`
-	MultiAddress    string `json:"multiAddress"`
-	EthereumAddress string `json:"ethereumAddress"`
-	PublicKey       string `json:"publicKey"`
-	Peers           int    `json:"peers"`
+	Network                 string `json:"network"`
+	MultiAddress            string `json:"multiAddress"`
+	EthereumAddress         string `json:"ethereumAddress"`
+	DarknodeRegistryAddress string `json:"darknodeRegistryAddress"`
+	RewardVaultAddress      string `json:"rewardVaultAddress"`
+	PublicKey               string `json:"publicKey"`
+	Peers                   int    `json:"peers"`
 }
 
 // StatusAdapter defines a struct which has status reading capability
@@ -41,6 +43,14 @@ func (adapter *StatusAdapter) Status() (Status, error) {
 	if err != nil {
 		return Status{}, err
 	}
+	darknodeRegistryAddr, err := adapter.DarknodeRegistryAddress()
+	if err != nil {
+		return Status{}, err
+	}
+	rewardVaultAddr, err := adapter.RewardVaultAddress()
+	if err != nil {
+		return Status{}, err
+	}
 	peers, err := adapter.Peers()
 	if err != nil {
 		return Status{}, err
@@ -51,10 +61,12 @@ func (adapter *StatusAdapter) Status() (Status, error) {
 	}
 	hexPk := "0x" + hex.EncodeToString(pk)
 	return Status{
-		Network:         network,
-		MultiAddress:    multiAddr.String(),
-		EthereumAddress: ethAddr,
-		PublicKey:       hexPk,
-		Peers:           peers,
+		Network:                 network,
+		MultiAddress:            multiAddr.String(),
+		EthereumAddress:         ethAddr,
+		DarknodeRegistryAddress: darknodeRegistryAddr,
+		RewardVaultAddress:      rewardVaultAddr,
+		PublicKey:               hexPk,
+		Peers:                   peers,
 	}, nil
 }

--- a/status/status.go
+++ b/status/status.go
@@ -11,17 +11,23 @@ import (
 type Writer interface {
 	WriteNetwork(network string) error
 	WriteMultiAddress(multiAddress identity.MultiAddress) error
-	WriteEthereumAddress(ethAddress string) error
 	WritePublicKey(publicKey []byte) error
+
+	WriteEthereumAddress(ethAddress string) error
+	WriteDarknodeRegistryAddress(address string) error
+	WriteRewardVaultAddress(address string) error
 }
 
 // Reader the address
 type Reader interface {
 	Network() (string, error)
 	MultiAddress() (identity.MultiAddress, error)
-	EthereumAddress() (string, error)
 	PublicKey() ([]byte, error)
 	Peers() (int, error)
+
+	EthereumAddress() (string, error)
+	DarknodeRegistryAddress() (string, error)
+	RewardVaultAddress() (string, error)
 }
 
 /*

--- a/status/status.go
+++ b/status/status.go
@@ -43,12 +43,14 @@ type Provider interface {
 }
 
 type provider struct {
-	mu              *sync.Mutex
-	dht             *dht.DHT
-	network         string
-	multiAddress    identity.MultiAddress
-	ethereumAddress string
-	publicKey       []byte
+	mu                      *sync.Mutex
+	dht                     *dht.DHT
+	network                 string
+	multiAddress            identity.MultiAddress
+	ethereumAddress         string
+	darknodeRegistryAddress string
+	rewardVaultAddress      string
+	publicKey               []byte
 }
 
 // NewProvider returns a new provider
@@ -94,6 +96,32 @@ func (sp *provider) WriteEthereumAddress(ethAddr string) error {
 // EthereumAddress gets the ethereum address
 func (sp *provider) EthereumAddress() (string, error) {
 	return sp.ethereumAddress, nil
+}
+
+// WriteDarknodeRegistryAddress writes darknodeRegistryAddress to the provider
+func (sp *provider) WriteDarknodeRegistryAddress(darknodeRegistryAddress string) error {
+	sp.mu.Lock()
+	defer sp.mu.Unlock()
+	sp.darknodeRegistryAddress = darknodeRegistryAddress
+	return nil
+}
+
+// DarknodeRegistryAddress gets the DarknodeRegistry contract address
+func (sp *provider) DarknodeRegistryAddress() (string, error) {
+	return sp.darknodeRegistryAddress, nil
+}
+
+// WriteRewardVaultAddress writes rewardVaultAddress to the provider
+func (sp *provider) WriteRewardVaultAddress(rewardVaultAddress string) error {
+	sp.mu.Lock()
+	defer sp.mu.Unlock()
+	sp.rewardVaultAddress = rewardVaultAddress
+	return nil
+}
+
+// RewardVaultAddress gets the RewardVault contract address
+func (sp *provider) RewardVaultAddress() (string, error) {
+	return sp.rewardVaultAddress, nil
 }
 
 // WritePublicKey writes the dark node's public key to the provider


### PR DESCRIPTION
**Description**

Adding contracts to Darknode statuses for use through the operator dashboard.

**Motivation**

Network information for the dashboard was previously set through Heroku environment variables. We are now migrating to a single application and will be retrieving network information directly from the darknode status.