### PR TITLE
Swarm gossiping - bug fixes

### DIFF
--- a/cmd/darknode/darknode.go
+++ b/cmd/darknode/darknode.go
@@ -112,8 +112,8 @@ func main() {
 	server := grpc.NewServer()
 
 	swarmClient := grpc.NewSwarmClient(store.SwarmMultiAddressStore(), multiAddr.Address())
-	swarmer := swarm.NewSwarmer(swarmClient, store.SwarmMultiAddressStore(), config.Alpha, &config.Keystore.EcdsaKey)
-	swarmService := grpc.NewSwarmService(swarm.NewServer(swarmer, store.SwarmMultiAddressStore(), config.Alpha), time.Millisecond)
+	swarmer := swarm.NewSwarmer(swarmClient, store.SwarmMultiAddressStore(), config.Alpha, &crypter)
+	swarmService := grpc.NewSwarmService(swarm.NewServer(swarmer, store.SwarmMultiAddressStore(), config.Alpha, &crypter), time.Millisecond)
 	swarmService.Register(server)
 
 	orderbook := orderbook.NewOrderbook(config.Keystore.RsaKey, store.OrderbookPointerStore(), store.OrderbookOrderStore(), store.OrderbookOrderFragmentStore(), &contractBinder, 5*time.Second, 32)

--- a/cmd/darknode/darknode.go
+++ b/cmd/darknode/darknode.go
@@ -184,7 +184,7 @@ func main() {
 		for _, multiAddr := range config.BootstrapMultiAddresses {
 			multi, err := store.SwarmMultiAddressStore().MultiAddress(multiAddr.Address())
 			if err != nil && err != swarm.ErrMultiAddressNotFound {
-				logger.Network(logger.LevelError, fmt.Sprintf("cannot get bootstrap details from store: %v", err))
+				logger.Network(logger.LevelError, fmt.Sprintf("cannot get bootstrap multi-address from store: %v", err))
 				continue
 			}
 			if err == nil {

--- a/leveldb/swarm_test.go
+++ b/leveldb/swarm_test.go
@@ -32,7 +32,7 @@ var _ = Describe("Swarm storage", func() {
 	})
 
 	Context("when adding new data", func() {
-		It("should not store new multi-addresses that have lower nonce", func() {
+		It("should store new multi-addresses", func() {
 			db := newDB(dbFile)
 			swarmMultiAddressTable := NewSwarmMultiAddressTable(db, 2*time.Second)
 
@@ -41,16 +41,10 @@ var _ = Describe("Swarm storage", func() {
 				err := swarmMultiAddressTable.PutMultiAddress(multiAddresses[i])
 				Expect(err).ShouldNot(HaveOccurred())
 
-				// Attempting to store the multi-address with the same nonce
-				// should not return an error.
-				err = swarmMultiAddressTable.PutMultiAddress(multiAddresses[i])
+				// Attempting to retrieve the multi-address should not return an error.
+				multi, err := swarmMultiAddressTable.MultiAddress(multiAddresses[i].Address())
 				Expect(err).ShouldNot(HaveOccurred())
-
-				// Attempting to store the multi-address with a lower nonce
-				// should return an error.
-				multiAddresses[i].Nonce = 100
-				err = swarmMultiAddressTable.PutMultiAddress(multiAddresses[i])
-				Expect(err).ShouldNot(HaveOccurred())
+				Expect(multi.String()).Should(Equal(multiAddresses[i].String()))
 			}
 		})
 	})
@@ -64,11 +58,6 @@ var _ = Describe("Swarm storage", func() {
 			for i := 0; i < len(multiAddresses); i++ {
 				err := swarmMultiAddressTable.PutMultiAddress(multiAddresses[i])
 				Expect(err).ShouldNot(HaveOccurred())
-			}
-			for i := 0; i < len(multiAddresses); i++ {
-				multiAddr, err := swarmMultiAddressTable.MultiAddress(multiAddresses[i].Address())
-				Expect(err).ShouldNot(HaveOccurred())
-				Expect(multiAddr.String()).Should(Equal(multiAddresses[i].String()))
 			}
 
 			// Sleep and then prune to expire the data

--- a/smpc/smpc_test.go
+++ b/smpc/smpc_test.go
@@ -176,8 +176,7 @@ func generateMocknodes(n, α int) ([]*mockNode, []identity.Address, []swarm.Mult
 			return nil, nil, nil, err
 		}
 
-		err = stores[i].PutMultiAddress(multiAddr)
-		if err != nil {
+		if err = stores[i].PutMultiAddress(multiAddr); err != nil {
 			return nil, nil, nil, err
 		}
 

--- a/swarm/swarm.go
+++ b/swarm/swarm.go
@@ -136,6 +136,7 @@ func (swarmer *swarmer) query(ctx context.Context, query identity.Address) (iden
 	if swarmer.MultiAddress().Address() == query {
 		return swarmer.MultiAddress(), nil
 	}
+	log.Printf("querying for %v", query)
 	// Is the multi-address present in the storer?
 	multiAddr, err := swarmer.storer.MultiAddress(query)
 	if err == nil {
@@ -145,11 +146,15 @@ func (swarmer *swarmer) query(ctx context.Context, query identity.Address) (iden
 		return identity.MultiAddress{}, err
 	}
 
+	log.Printf("not in store: %v", query)
+
 	// If multi-address is not present in the store, query for a maximum of α random nodes.
 	randomMultiAddrs, err := randomMultiAddrs(swarmer.storer, swarmer.MultiAddress().Address(), swarmer.α)
 	if err != nil {
 		return identity.MultiAddress{}, err
 	}
+
+	log.Printf("got %v addrs", len(randomMultiAddrs))
 
 	// Create two maps to records the addrs we have seen and queried
 	seenMu := new(sync.Mutex)
@@ -196,6 +201,8 @@ func (swarmer *swarmer) query(ctx context.Context, query identity.Address) (iden
 				log.Printf("cannot query %v: %v", multiAddr.Address(), err)
 				return
 			}
+
+			log.Printf("got back %v from %v", len(multiAddrs), multiAddr.Address())
 
 			dispatch.ForAll(multiAddrs, func(j int) {
 

--- a/swarm/swarm.go
+++ b/swarm/swarm.go
@@ -355,6 +355,7 @@ func (server *server) Pong(ctx context.Context, from identity.MultiAddress) erro
 func (server *server) Query(ctx context.Context, query identity.Address) (identity.MultiAddresses, error) {
 	multiAddr, err := server.multiAddrStore.MultiAddress(query)
 	if err == nil {
+		log.Printf("Found multiaddress for %v", multiAddr.Address())
 		return []identity.MultiAddress{multiAddr}, nil
 	}
 	return randomMultiAddrs(server.multiAddrStore, server.swarmer.MultiAddress().Address(), server.α)
@@ -396,5 +397,6 @@ func randomMultiAddrs(storer MultiAddressStorer, self identity.Address, α int) 
 		results = append(results, multiAddr)
 	}
 
+	log.Printf("Returning %v multi-addresses", len(results))
 	return results, nil
 }

--- a/swarm/swarm.go
+++ b/swarm/swarm.go
@@ -298,12 +298,12 @@ type server struct {
 	binder         contract.Binder
 }
 
-func NewServer(swarmer Swarmer, multiAddrStore MultiAddressStorer, α int, binder contract.Binder) Server {
+func NewServer(swarmer Swarmer, multiAddrStore MultiAddressStorer, α int) Server {
 	return &server{
 		swarmer:        swarmer,
 		multiAddrStore: multiAddrStore,
 		α:              α,
-		binder:         binder,
+		// binder:         binder,
 	}
 }
 
@@ -352,17 +352,9 @@ func (server *server) Pong(ctx context.Context, from identity.MultiAddress) erro
 	// Compare the nonce and see if we need to gossip the ping.
 	oldMulti, err := server.multiAddrStore.MultiAddress(from.Address())
 	if err == ErrMultiAddressNotFound || oldMulti.Nonce < from.Nonce {
-		err := server.multiAddrStore.PutMultiAddress(from)
-		if err != nil {
-			return err
-		}
-		return server.swarmer.BroadcastMultiAddress(ctx, from)
+		return server.multiAddrStore.PutMultiAddress(from)
 	}
-	if err != nil && err != ErrMultiAddressNotFound {
-		return err
-	}
-
-	return nil
+	return err
 }
 
 func (server *server) Query(ctx context.Context, query identity.Address) (identity.MultiAddresses, error) {

--- a/swarm/swarm.go
+++ b/swarm/swarm.go
@@ -280,11 +280,11 @@ func (swarmer *swarmer) pingNodes(ctx context.Context, multiAddr identity.MultiA
 		multiAddrs[i] = multiAddrs[len(multiAddrs)-1]
 		multiAddrs = multiAddrs[:len(multiAddrs)-1]
 
-		go func(multi identity.MultiAddress) {
+		// go func(multi identity.MultiAddress) {
 			if err := pingNode(multi); err != nil {
 				log.Printf("cannot ping node with address %v: %v", multi, err)
 			}
-		}(multi)
+		// }(multi)
 
 		seenAddrs[multi.Address()] = struct{}{}
 	}

--- a/swarm/swarm.go
+++ b/swarm/swarm.go
@@ -311,13 +311,13 @@ func NewServer(swarmer Swarmer, multiAddrStore MultiAddressStorer, α int, verif
 
 // Ping implements the Server interface.
 func (server *server) Ping(ctx context.Context, multiAddr identity.MultiAddress) error {
-	// Verify the signature
-	if err := server.verifier.Verify(multiAddr.Hash(), multiAddr.Signature); err != nil {
+	// Pong back
+	if err := server.swarmer.Pong(ctx, multiAddr); err != nil {
 		return err
 	}
 
-	// Pong back
-	if err := server.swarmer.Pong(ctx, multiAddr); err != nil {
+	// Verify the signature
+	if err := server.verifier.Verify(multiAddr.Hash(), multiAddr.Signature); err != nil {
 		return err
 	}
 
@@ -351,7 +351,7 @@ func (server *server) Pong(ctx context.Context, from identity.MultiAddress) erro
 	return err
 }
 
-// Query implements the Server interface.
+// Query implements the Swarmer interface.
 func (server *server) Query(ctx context.Context, query identity.Address) (identity.MultiAddresses, error) {
 	multiAddr, err := server.multiAddrStore.MultiAddress(query)
 	if err == nil {

--- a/swarm/swarm.go
+++ b/swarm/swarm.go
@@ -249,13 +249,11 @@ func (swarmer *swarmer) pingNodes(ctx context.Context, multiAddr identity.MultiA
 	}
 
 	if len(multiAddrs) <= swarmer.α {
-		for _, multi := range multiAddrs {
-			go func(multi identity.MultiAddress) {
-				if err := pingNode(multi); err != nil {
-					log.Printf("cannot ping node with address %v: %v", multi, err)
-				}
-			}(multi)
-		}
+		dispatch.CoForAll(multiAddrs, func(i int) {
+			if err := pingNode(multiAddrs[i]); err != nil {
+				log.Printf("cannot ping node with address %v: %v", multiAddrs[i], err)
+			}
+		})
 		return nil
 	}
 

--- a/swarm/swarm.go
+++ b/swarm/swarm.go
@@ -202,6 +202,11 @@ func (swarmer *swarmer) query(ctx context.Context, query identity.Address) (iden
 				return
 			}
 
+			// Process only the first α multi-addresses returned.
+			if len(multiAddrs) > swarmer.α {
+				multiAddrs = multiAddrs[:swarmer.α]
+			}
+
 			log.Printf("got back %v from %v", len(multiAddrs), multiAddr.Address())
 
 			dispatch.ForAll(multiAddrs, func(j int) {

--- a/swarm/swarm.go
+++ b/swarm/swarm.go
@@ -351,6 +351,7 @@ func (server *server) Pong(ctx context.Context, from identity.MultiAddress) erro
 	return err
 }
 
+// Query implements the Server interface.
 func (server *server) Query(ctx context.Context, query identity.Address) (identity.MultiAddresses, error) {
 	multiAddr, err := server.multiAddrStore.MultiAddress(query)
 	if err == nil {

--- a/swarm/swarm.go
+++ b/swarm/swarm.go
@@ -311,13 +311,13 @@ func NewServer(swarmer Swarmer, multiAddrStore MultiAddressStorer, α int, verif
 
 // Ping implements the Server interface.
 func (server *server) Ping(ctx context.Context, multiAddr identity.MultiAddress) error {
-	// Pong back
-	if err := server.swarmer.Pong(ctx, multiAddr); err != nil {
+	// Verify the signature
+	if err := server.verifier.Verify(multiAddr.Hash(), multiAddr.Signature); err != nil {
 		return err
 	}
 
-	// Verify the signature
-	if err := server.verifier.Verify(multiAddr.Hash(), multiAddr.Signature); err != nil {
+	// Pong back
+	if err := server.swarmer.Pong(ctx, multiAddr); err != nil {
 		return err
 	}
 

--- a/swarm/swarm.go
+++ b/swarm/swarm.go
@@ -164,6 +164,7 @@ func (swarmer *swarmer) query(ctx context.Context, query identity.Address) (iden
 			break
 		}
 		if _, ok := seenAddrs[query]; ok {
+			log.Printf("%v found!!!", query)
 			target, err := swarmer.storer.MultiAddress(query)
 			if err != nil {
 				logger.Error("cannot get multiAddress from the storer")
@@ -204,6 +205,7 @@ func (swarmer *swarmer) query(ctx context.Context, query identity.Address) (iden
 					return
 				}
 
+				log.Printf("Got: %v", multi.Address())
 				// Mark the new multi as seen and add to the query backlog.
 				seenMu.Lock()
 				if _, ok := seenAddrs[multi.Address()]; ok {
@@ -214,6 +216,7 @@ func (swarmer *swarmer) query(ctx context.Context, query identity.Address) (iden
 				randomMultiAddrs = append(randomMultiAddrs, multi)
 				seenMu.Unlock()
 
+				log.Printf("%v is new info", multi.Address())
 				// Put the new multi in our storer if it has a higher nonce
 				oldMulti, err := swarmer.storer.MultiAddress(multi.Address())
 				if err != nil && err != ErrMultiAddressNotFound {
@@ -221,6 +224,7 @@ func (swarmer *swarmer) query(ctx context.Context, query identity.Address) (iden
 					return
 				}
 				if err == ErrMultiAddressNotFound || oldMulti.Nonce < multi.Nonce {
+					log.Printf("%v is stored", multi.Address())
 					if err = swarmer.storer.PutMultiAddress(multi); err != nil {
 						log.Printf("cannot store %v: %v", multi.Address(), err)
 						return

--- a/swarm/swarm.go
+++ b/swarm/swarm.go
@@ -7,6 +7,7 @@ import (
 	"math/rand"
 	"sync"
 
+	"github.com/republicprotocol/republic-go/contract"
 	"github.com/republicprotocol/republic-go/crypto"
 	"github.com/republicprotocol/republic-go/dispatch"
 	"github.com/republicprotocol/republic-go/identity"
@@ -294,13 +295,15 @@ type server struct {
 	swarmer        Swarmer
 	multiAddrStore MultiAddressStorer
 	α              int
+	binder         contract.Binder
 }
 
-func NewServer(swarmer Swarmer, multiAddrStore MultiAddressStorer, α int) Server {
+func NewServer(swarmer Swarmer, multiAddrStore MultiAddressStorer, α int, binder contract.Binder) Server {
 	return &server{
 		swarmer:        swarmer,
 		multiAddrStore: multiAddrStore,
 		α:              α,
+		binder:         binder,
 	}
 }
 
@@ -310,6 +313,13 @@ func (server *server) Ping(ctx context.Context, multiAddr identity.MultiAddress)
 	if err := verifier.Verify(multiAddr.Hash(), multiAddr.Signature); err != nil {
 		return err
 	}
+	// registered, err := server.binder.IsRegistered(multiAddr.Address())
+	// if err != nil {
+	// 	return err
+	// }
+	// if !registered {
+	// 	return nil
+	// }
 
 	// Pong back
 	if err := server.swarmer.Pong(ctx, multiAddr); err != nil {

--- a/swarm/swarm_test.go
+++ b/swarm/swarm_test.go
@@ -80,7 +80,7 @@ var _ = Describe("Swarm", func() {
 
 	Context("when connecting to the network", func() {
 
-		Context("when traders are honest, they", func() {
+		Context("when nodes are honest, they", func() {
 
 			AfterEach(func() {
 				os.RemoveAll("./tmp")
@@ -127,11 +127,12 @@ var _ = Describe("Swarm", func() {
 					peers, err := swarmers[i].Peers()
 					Expect(err).ShouldNot(HaveOccurred())
 					Expect(len(peers)).To(BeNumerically(">=", numberOfClients*9/10))
+					log.Printf("Node %v: Connected to %v peers.", i, len(peers)-1)
 				})
 			})
 		})
 
-		Context("when some traders are dishonest, they", func() {
+		Context("when some nodes are dishonest, they", func() {
 
 			AfterEach(func() {
 				os.RemoveAll("./tmp")
@@ -158,6 +159,7 @@ var _ = Describe("Swarm", func() {
 					peers, err := swarmers[i].Peers()
 					Expect(err).ShouldNot(HaveOccurred())
 					Expect(len(peers)).To(BeNumerically(">", numberOfBootstrapClients))
+					log.Printf("Node %v: Connected to %v peers.", i, len(peers)-1)
 				})
 			})
 		})

--- a/swarm/swarm_test.go
+++ b/swarm/swarm_test.go
@@ -20,9 +20,9 @@ import (
 var _ = Describe("Swarm", func() {
 
 	var (
-		numberOfClients          = 50
+		numberOfClients          = 100
 		numberOfBootstrapClients = 5
-		α                        = 3
+		α                        = 4
 	)
 
 	registerClientsAndBootstrap := func(ctx context.Context, honest bool) ([]Client, []Swarmer, *testutils.MockServerHub, error) {

--- a/swarm/swarm_test.go
+++ b/swarm/swarm_test.go
@@ -161,7 +161,7 @@ var _ = Describe("Swarm", func() {
 					Expect(err).ShouldNot(HaveOccurred())
 				})
 
-				time.Sleep(time.Second)
+				time.Sleep(2 * time.Second)
 				dispatch.CoForAll(numberOfClients, func(i int) {
 					defer GinkgoRecover()
 

--- a/swarm/swarm_test.go
+++ b/swarm/swarm_test.go
@@ -6,6 +6,7 @@ import (
 	"math/rand"
 	"os"
 	"sync"
+	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -160,6 +161,7 @@ var _ = Describe("Swarm", func() {
 					Expect(err).ShouldNot(HaveOccurred())
 				})
 
+				time.Sleep(time.Second)
 				dispatch.CoForAll(numberOfClients, func(i int) {
 					defer GinkgoRecover()
 

--- a/testutils/mock_swarmer.go
+++ b/testutils/mock_swarmer.go
@@ -145,8 +145,7 @@ func NewMockSwarmClient(MockServerHub *MockServerHub, key *crypto.EcdsaKey, clie
 		return MockSwarmClient{}, nil, err
 	}
 	store := db.SwarmMultiAddressStore()
-	err = store.PutMultiAddress(multiAddr)
-	if err != nil {
+	if err = store.PutMultiAddress(multiAddr); err != nil {
 		return MockSwarmClient{}, nil, err
 	}
 

--- a/testutils/mock_swarmer.go
+++ b/testutils/mock_swarmer.go
@@ -2,6 +2,7 @@ package testutils
 
 import (
 	"context"
+	"crypto/rsa"
 	"errors"
 	"fmt"
 	"log"
@@ -9,9 +10,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/republicprotocol/republic-go/crypto"
 	"github.com/republicprotocol/republic-go/identity"
 	"github.com/republicprotocol/republic-go/leveldb"
+	"github.com/republicprotocol/republic-go/registry"
 	"github.com/republicprotocol/republic-go/swarm"
 )
 
@@ -127,20 +128,20 @@ type MockSwarmClient struct {
 	clientType ClientType
 }
 
-func NewMockSwarmClient(MockServerHub *MockServerHub, key *crypto.EcdsaKey, clientType ClientType) (MockSwarmClient, swarm.MultiAddressStorer, error) {
-	multiAddr, err := identity.Address(key.Address()).MultiAddress()
+func NewMockSwarmClient(MockServerHub *MockServerHub, clientType ClientType, verifier *registry.Crypter) (MockSwarmClient, swarm.MultiAddressStorer, error) {
+	multiAddr, err := RandomMultiAddress()
 	if err != nil {
 		return MockSwarmClient{}, nil, err
 	}
 	multiAddr.Nonce = 1
-	signature, err := key.Sign(multiAddr.Hash())
+	signature, err := verifier.Sign(multiAddr.Hash())
 	if err != nil {
 		return MockSwarmClient{}, nil, err
 	}
 	multiAddr.Signature = signature
 
 	// Create leveldb store and store own multiAddress.
-	db, err := leveldb.NewStore(fmt.Sprintf("./tmp/swarmer-%v.out", key.Address()), 72*time.Hour)
+	db, err := leveldb.NewStore(fmt.Sprintf("./tmp/swarmer-%v.out", multiAddr.Address()), 72*time.Hour)
 	if err != nil {
 		return MockSwarmClient{}, nil, err
 	}
@@ -150,7 +151,7 @@ func NewMockSwarmClient(MockServerHub *MockServerHub, key *crypto.EcdsaKey, clie
 	}
 
 	return MockSwarmClient{
-		addr:       identity.Address(key.Address()),
+		addr:       identity.Address(multiAddr.Address()),
 		store:      store,
 		serverHub:  MockServerHub,
 		clientType: clientType,
@@ -243,4 +244,20 @@ func (client *MockSwarmClient) MultiAddress() identity.MultiAddress {
 func randomSleep() {
 	r := rand.Intn(120)
 	time.Sleep(time.Duration(r) * time.Millisecond)
+}
+
+type MockSwarmBinder struct {
+}
+
+// NewMockSwarmBinder returns a MockSwarmBinder
+func NewMockSwarmBinder() *MockSwarmBinder {
+	return &MockSwarmBinder{}
+}
+
+func (binder *MockSwarmBinder) IsRegistered(darknodeAddr identity.Address) (bool, error) {
+	return true, nil
+}
+
+func (binder *MockSwarmBinder) PublicKey(addr identity.Address) (rsa.PublicKey, error) {
+	return rsa.PublicKey{}, nil
 }


### PR DESCRIPTION
**Description**

This PR addresses the following issues with the gossip protocol in the `swarm` package.
- [Bug] Improve the speed of bootstrapping.
- Verify that darknodes are registered with the DNR before storing them.
- Make `ping` of α random multi-addresses concurrent.
- Prevent DoS attacks by only querying α multi-addresses from the list of multi-addresses returned by other clients.