### PR TITLE
Separate config and keystore files

### DIFF
--- a/cmd/confgen/confgen.go
+++ b/cmd/confgen/confgen.go
@@ -8,24 +8,23 @@ import (
 
 	"github.com/republicprotocol/republic-go/cmd/darknode/config"
 	"github.com/republicprotocol/republic-go/contract"
-	"github.com/republicprotocol/republic-go/crypto"
 	"github.com/republicprotocol/republic-go/identity"
 	"github.com/republicprotocol/republic-go/logger"
 )
 
 func main() {
 	network := flag.String("network", "nightly", "Republic Protocol network")
+	address := flag.String("address", "", "address")
 	oracleAddress := flag.String("oracleAddress", "", "Oracle address")
 
 	flag.Parse()
 
-	if *oracleAddress == "" {
+	if *address == "" {
 		log.Fatalf("oracle address not specified")
 	}
 
-	keystore, err := crypto.RandomKeystore()
-	if err != nil {
-		log.Fatalf("cannot create keystore: %v", err)
+	if *oracleAddress == "" {
+		log.Fatalf("oracle address not specified")
 	}
 
 	var ethereumConfig contract.Config
@@ -51,10 +50,9 @@ func main() {
 	}
 
 	conf := config.Config{
-		Keystore:                keystore,
 		Host:                    "0.0.0.0",
 		Port:                    "18514",
-		Address:                 identity.Address(keystore.Address()),
+		Address:                 identity.Address(*address),
 		OracleAddress:           identity.Address(*oracleAddress),
 		BootstrapMultiAddresses: []identity.MultiAddress{},
 		Logs: logger.Options{

--- a/cmd/darknode/config/config.go
+++ b/cmd/darknode/config/config.go
@@ -5,13 +5,11 @@ import (
 	"os"
 
 	"github.com/republicprotocol/republic-go/contract"
-	"github.com/republicprotocol/republic-go/crypto"
 	"github.com/republicprotocol/republic-go/identity"
 	"github.com/republicprotocol/republic-go/logger"
 )
 
 type Config struct {
-	Keystore crypto.Keystore `json:"keystore"`
 	Ethereum contract.Config `json:"ethereum"` // TODO: Darknode package should not be dependent on blockchain/ethereum
 	Logs     logger.Options  `json:"logs"`
 

--- a/cmd/darknode/darknode.go
+++ b/cmd/darknode/darknode.go
@@ -43,7 +43,6 @@ func main() {
 	// Parse command-line arguments
 	configParam := flag.String("config", path.Join(os.Getenv("HOME"), ".darknode/config.json"), "JSON configuration file")
 	keystoreParam := flag.String("keystore", path.Join(os.Getenv("HOME"), ".darknode/keystore.json"), "JSON keystore configuration file")
-	networkParam := flag.String("network", path.Join(os.Getenv("HOME"), ".darknode/network.json"), "JSON network configuration file")
 	dataParam := flag.String("data", path.Join(os.Getenv("HOME"), ".darknode/data"), "Data directory")
 	flag.Parse()
 
@@ -54,11 +53,6 @@ func main() {
 	}
 	// Load keystore configuration file
 	keystore, err := crypto.NewKeystoreFromJSONFile(*keystoreParam)
-	if err != nil {
-		log.Fatalf("cannot load config: %v", err)
-	}
-	// Load network config file
-	ethConfig, err := contract.NewConfigFromJSONFile(*networkParam)
 	if err != nil {
 		log.Fatalf("cannot load config: %v", err)
 	}
@@ -77,7 +71,7 @@ func main() {
 	log.Printf("address %v", multiAddr)
 
 	// Connect to Ethereum
-	conn, err := contract.Connect(ethConfig)
+	conn, err := contract.Connect(config.Ethereum)
 	if err != nil {
 		log.Fatalf("cannot connect to ethereum: %v", err)
 	}
@@ -145,7 +139,7 @@ func main() {
 	streamerService.Register(server)
 
 	var ethNetwork string
-	if ethConfig.Network == "mainnet" {
+	if config.Ethereum.Network == "mainnet" {
 		ethNetwork = "mainnet"
 	} else {
 		ethNetwork = "kovan"

--- a/cmd/darknode/darknode.go
+++ b/cmd/darknode/darknode.go
@@ -54,7 +54,7 @@ func main() {
 	// Load keystore configuration file
 	keystore, err := crypto.NewKeystoreFromJSONFile(*keystoreParam)
 	if err != nil {
-		log.Fatalf("cannot load config: %v", err)
+		log.Fatalf("cannot load keystore config file: %v", err)
 	}
 
 	// Get IP-address

--- a/contract/config.go
+++ b/contract/config.go
@@ -1,5 +1,10 @@
 package contract
 
+import (
+	"encoding/json"
+	"os"
+)
+
 // Network is used to represent a Republic Protocol network.
 type Network string
 
@@ -27,4 +32,19 @@ type Config struct {
 	RewardVaultAddress      string  `json:"rewardVaultAddress"`
 	RenExBalancesAddress    string  `json:"renExBalancesAddress"`
 	RenExSettlementAddress  string  `json:"renExSettlementAddress"`
+}
+
+// NewConfigFromJSONFile unmarshals a JSON into a Config object
+func NewConfigFromJSONFile(filename string) (Config, error) {
+	file, err := os.Open(filename)
+	if err != nil {
+		return Config{}, err
+	}
+	defer file.Close()
+
+	conf := Config{}
+	if err := json.NewDecoder(file).Decode(&conf); err != nil {
+		return Config{}, err
+	}
+	return conf, nil
 }

--- a/crypto/keystore.go
+++ b/crypto/keystore.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/crypto/randentropy"
@@ -67,6 +68,21 @@ func (keystore *Keystore) NewKeystore(ecdsaKey EcdsaKey, rsaKey RsaKey) Keystore
 		EcdsaKey: ecdsaKey,
 		RsaKey:   rsaKey,
 	}
+}
+
+// NewKeystoreFromJSONFile unmarshals an unencrypted keystore JSON file
+func NewKeystoreFromJSONFile(filename string) (Keystore, error) {
+	file, err := os.Open(filename)
+	if err != nil {
+		return Keystore{}, err
+	}
+	defer file.Close()
+
+	ks := Keystore{}
+	if err := json.NewDecoder(file).Decode(&ks); err != nil {
+		return Keystore{}, err
+	}
+	return ks, nil
 }
 
 // EncryptToJSON will encrypt the EcdsaKey and RsaKey in the Keystore. It

--- a/testutils/rand_config.go
+++ b/testutils/rand_config.go
@@ -22,7 +22,6 @@ func RandomConfigs(n int, b int) ([]config.Config, error) {
 
 		addr := identity.Address(keystore.Address())
 		configs = append(configs, config.Config{
-			Keystore:                keystore,
 			Host:                    "0.0.0.0",
 			Port:                    fmt.Sprintf("%d", 18514+i),
 			Address:                 addr,


### PR DESCRIPTION
**Description**

At the moment, Darknodes have a single configuration file that contains all configuration data — including their private keys. This task is focused on separating the configuration file into multiple files.

**Motivation**

This allows persistent configurations such as private key information to be preserved even when dynamic configurations such as network information are constantly updated.

**Design**

The current keystore component of the current `config.json` file will be split into its own `keystore.json`.

Packages that are affected include: `cmd/darknode` and `cmd/confgen` among others.

**Unresolved Issues**

Other repositories that utilise the darknode config will also need to be updated. These include: `darknode-cli`and `lotan`. Such changes are not addressed by this PR.