### PR TITLE
Adding 'omitempty' to json tags

### DIFF
--- a/order/order.go
+++ b/order/order.go
@@ -200,18 +200,18 @@ func (status Status) String() string {
 
 // An Order represents the want to perform a trade of assets.
 type Order struct {
-	Signature  Signature  `json:"signature"`
-	ID         ID         `json:"id"`
-	Type       Type       `json:"type"`
-	Parity     Parity     `json:"parity"`
-	Settlement Settlement `json:"settlement"`
-	Expiry     time.Time  `json:"expiry"`
+	Signature  Signature  `json:"signature,omitempty"`
+	ID         ID         `json:"id,omitempty"`
+	Type       Type       `json:"type,omitempty"`
+	Parity     Parity     `json:"parity,omitempty"`
+	Settlement Settlement `json:"settlement,omitempty"`
+	Expiry     time.Time  `json:"expiry,omitempty"`
 
-	Tokens        Tokens `json:"tokens"`
-	Price         CoExp  `json:"price"`
-	Volume        CoExp  `json:"volume"`
-	MinimumVolume CoExp  `json:"minimumVolume"`
-	Nonce         uint64 `json:"nonce"`
+	Tokens        Tokens `json:"tokens,omitempty"`
+	Price         CoExp  `json:"price,omitempty"`
+	Volume        CoExp  `json:"volume,omitempty"`
+	MinimumVolume CoExp  `json:"minimumVolume,omitempty"`
+	Nonce         uint64 `json:"nonce,omitempty"`
 }
 
 // NewOrder returns a new Order and computes the ID.


### PR DESCRIPTION
**Description**

Adding `omitempty` to JSON tags for Order objects.

**Motivation**

This allows us to test missing fields with greater ease, as we can simply set the field to null and it will be omitted from the marshaled bytes. Without the tag, we would have to create a new Order struct for each missing field.